### PR TITLE
Add context manager

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,15 +13,22 @@ The latest release is available on PyPI
 Example Usage
 ------------
 
-From within an HTCondor ``+WantIOProxy = true`` job::
-  
+Using `with` syntax (**recommended**)::
+  >>> import htchirp
+  >>> with htchirp.HTChirp() as chirp:
+  >>>     chirp.ulog('Logging use of Chirp in Python')
+  >>>     me = chirp.whoami()
+  >>>     chirp.set_job_attr('UsingPythonChirp', 'True')
+  >>>     using_chirp = chirp.get_job_attr('UsingPythonChirp')
+  >>> me
+  'CONDOR'
+  >>> using_chirp
+  'true'
+
+Using manual connection and disconnection (**not recommended**)::
   >>> import htchirp
   >>> chirp = htchirp.HTChirp()
-  >>> chirp.whoami()
-  'CONDOR'
-  >>> chirp.set_job_attr('UsingPythonChirp', 'True')
-  >>> chirp.get_job_attr('UsingPythonChirp')
-  'true'
+  >>> chirp.connect()
   >>> chirp.write('Important output 1\n', '/tmp/my-job-output', 'cwa')
   19
   >>> chirp.write('Important output 2\n', '/tmp/my-job-output', 'cwa')
@@ -30,10 +37,8 @@ From within an HTCondor ``+WantIOProxy = true`` job::
   'Important output 1\nImportant output 2\n'
   >>> chirp.fetch('/tmp/my-job-output', './my-job-output')
   38
-  >>> open('./my-job-output').read()
-  'Important output 1\nImportant output 2\n'
-  >>> chirp.ulog('Logging use of Chirp in Python')
-
+  >>> chirp.disconnect()
+  
 For more commands, see ``help(htchirp.HTChirp)``.
 For a broader explanation of ``condor_chirp``, see 
 http://research.cs.wisc.edu/htcondor/manual/current/condor_chirp.html

--- a/htchirp/htchirp.py
+++ b/htchirp/htchirp.py
@@ -24,39 +24,6 @@ def quote(chirp_string):
 
 
 class HTChirp:
-
-    """Chirp client provider for HTCondor
-
-    Provides a Chirp client compatible with the HTCondor Chirp implementation.
-
-    If the host and port of a Chirp server are not specified, you are assumed
-    to be running in a HTCondor "+WantIOProxy = true" job and that
-    $_CONDOR_SCRATCH_DIR/.chirp.config contains the host, port, and cookie for
-    connecting to the embedded chirp proxy.
-
-    :param host: the hostname or ip of the Chirp server
-    :param port: the port of the Chirp server
-    :param auth: a list of authentication methods to try
-    :param cookie: the cookie string, if trying cookie authentication
-    :param timeout: socket timeout, in seconds"""
-
-
-    def __init__(self, host = None, port = None,
-                     auth = ["cookie"], cookie = None, timeout = 10):
-        self.client = HTChirpClient(host, port, auth, cookie, timeout)
-
-    ## special methods
-
-    def __enter__(self):
-        """Establish a connection with the Chirp server"""
-        self.client.connect()
-        return self.client
-
-    def __exit__(self, *args):
-        """Close the connection with the Chirp server"""
-        self.client.disconnect()
-
-class HTChirpClient:
     """Chirp client for HTCondor
 
     A Chirp client compatible with the HTCondor Chirp implementation.
@@ -143,6 +110,15 @@ class HTChirpClient:
                 "Could not authenticate with methods {0}".format(auth))
 
     # special methods
+
+    def __enter__(self):
+        """Establish a connection with the Chirp server"""
+        self.connect()
+        return self
+
+    def __exit__(self, *args):
+        """Close the connection with the Chirp server"""
+        self.disconnect()
 
     def __del__(self):
         """Disconnect from the Chirp server when this object goes away"""

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='htchirp',
-    version='0.2',
+    version='1.0',
     description='Pure Python Chirp client for HTCondor',
     keywords='htcondor chirp',
     url='https://github.com/htcondor/htchirp',


### PR DESCRIPTION
Adds context manager (e.g. `with HTChirp as chirp: ...`) to reduce the frequency of connections to the chirp server. Using HTChirp without context now requires manual connection to/disconnection from the chirp server before sending commands.