### PR TITLE
Added MANIFEST.in and setup.cfg to ensure distribution of license

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE README.rst

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[bdist_wheel]
+universal = 1
+
+[metadata]
+license_file = LICENSE


### PR DESCRIPTION
This PR adds the following files to make sure that the `LICENSE` file is included in distributions

- `MANIFEST.in` for `setup.py sdist`
- `setup.cfg` for `setup.py bdist_wheel`