### PR TITLE
Fix _get_line_data for Python 3 compatibility

### DIFF
--- a/htchirp/htchirp.py
+++ b/htchirp/htchirp.py
@@ -300,7 +300,7 @@ class HTChirp:
         data = b""
         while True:
             data += self.socket.recv(self.__class__.CHIRP_LINE_MAX)
-            if (data[-1] == b"\n"):
+            if (data.decode()[-1] == "\n"):
                 break
         return data.decode()
 


### PR DESCRIPTION
Hello,

I found this bug when running htchirp with Python 3.
Due to the differences in the way Python 2 and 3 handle strings, the altered expression will evaluate differently in each version.

Slicing a byte array in Python 2 will return an str object:
```
>>> type(b"foo"[1])
<type 'str'>
```

The same operation in Python 3 returns an int object:
```
>>> type(b"foo"[1])
<class 'int'>
```

To address this issue, I propose decoding the byte array before slicing and then handling the result as a string.

The following works the same in both versions:
```
>>> type(b"foo".decode()[1])
<class 'str'>
```

Thanks,
Bruno