### PR TITLE
Fix getdir to properly call getlongdir

### DIFF
--- a/htchirp/htchirp.py
+++ b/htchirp/htchirp.py
@@ -882,7 +882,7 @@ class HTChirp:
 
         """
 
-        names = ["device", "inode", "mode", "nlink", "uid", "gid", "rdevice"
+        names = ["device", "inode", "mode", "nlink", "uid", "gid", "rdevice",
                      "size", "blksize", "blocks", "atime", "mtime", "ctime"]
 
         length = int(self._simple_command("getlongdir {0}\n".format(quote(remote_path))))

--- a/htchirp/htchirp.py
+++ b/htchirp/htchirp.py
@@ -904,7 +904,7 @@ class HTChirp:
         """
 
         if stat_dict == True:
-            return getlongdir(remote_path)
+            return self.getlongdir(remote_path)
         else:
 
             length = int(self._simple_command("getdir {0}\n".format(quote(remote_path))))


### PR DESCRIPTION
The function `getlongdir` is not defined globally and will cause `getdir` to fail when called with stat_dict=True.
This change solves the problem by referencing the class with `self` when calling the function.