### PR TITLE
Fix chmod to interpret mode as an octal

### DIFF
--- a/htchirp/htchirp.py
+++ b/htchirp/htchirp.py
@@ -1086,7 +1086,7 @@ class HTChirp:
 
         """
 
-        self._simple_command("chmod {0} {1}\n".format(quote(remote_path), int(mode)))
+        self._simple_command("chmod {0} {1}\n".format(quote(remote_path), int(mode, 8)))
 
 
     def chown(self, remote_path, uid, gid):


### PR DESCRIPTION
The function chmod currently interprets `mode` as a decimal instead of octal, causing the file permission to be incorrectly set.
Simply adding the base parameter to the int conversion would solve the problem.